### PR TITLE
Move the output name overlay to the bottom left

### DIFF
--- a/src/overlay.c
+++ b/src/overlay.c
@@ -132,7 +132,7 @@ void window_map(GtkWidget *widget, gpointer data) {
       &layer_surface_listener, output);
 
   zwlr_layer_surface_v1_set_anchor(output->overlay_layer_surface,
-      ZWLR_LAYER_SURFACE_V1_ANCHOR_TOP |
+      ZWLR_LAYER_SURFACE_V1_ANCHOR_BOTTOM |
       ZWLR_LAYER_SURFACE_V1_ANCHOR_LEFT);
 
   resize(output);


### PR DESCRIPTION
The output name overlay renders on the top left by default. At the same
time, wdisplays renders the output previews on its top left corner too.

The results is that the overlay covering the output previews, making
seeing it and interacting with it tricky.

Moving the output name to the bottom left makes sure there's never any
overlap between it and the draggable previews shows for each output.