### PR TITLE
Fix Icon value of MIME-Type wdiplays.desktop file!

### DIFF
--- a/resources/wdisplays.desktop.in
+++ b/resources/wdisplays.desktop.in
@@ -5,4 +5,4 @@ Name=wdisplays
 Comment=Wlroots display configuration
 Categories=GTK;Settings;DesktopSettings;
 Exec=wdisplays
-Icon=@app_id@
+Icon=wdisplays


### PR DESCRIPTION
This is a correction of the wrong Icon value in the wdisplays.desktop MIME-Type file!

Just one value is replaced to work correct! Hopefully this will work on every Desktop Enviroment!!