### PR TITLE
Fixed menu scaling issue by disabling the use of GTK popover

### DIFF
--- a/src/headform.c
+++ b/src/headform.c
@@ -195,6 +195,7 @@ static void wd_head_form_init(WdHeadForm *form) {
   g_menu_append(rotate_menu, "Rotate 180°", "head.rotate(180)");
   g_menu_append(rotate_menu, "Rotate 270°", "head.rotate(270)");
   gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(priv->rotate_button), G_MENU_MODEL(rotate_menu));
+  gtk_menu_button_set_use_popover(GTK_MENU_BUTTON(priv->rotate_button), false);
 
   static const GVariantType * const mode_types[] = {
     G_VARIANT_TYPE_INT32,
@@ -255,6 +256,7 @@ void wd_head_form_update(WdHeadForm *form, const struct wd_head *head,
       g_menu_append_item(mode_menu, item);
     }
     gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(priv->mode_button), G_MENU_MODEL(mode_menu));
+    gtk_menu_button_set_use_popover(GTK_MENU_BUTTON(priv->mode_button), false);
     // Mode entries
     int w = head->custom_mode.width;
     int h = head->custom_mode.height;

--- a/src/main.c
+++ b/src/main.c
@@ -1039,6 +1039,7 @@ static void activate(GtkApplication* app, gpointer user_data) {
   g_menu_append(main_menu, "_Show Screen Contents", "app.capture-screens");
   g_menu_append(main_menu, "_Overlay Screen Names", "app.show-overlay");
   gtk_menu_button_set_menu_model(GTK_MENU_BUTTON(state->menu_button), G_MENU_MODEL(main_menu));
+  gtk_menu_button_set_use_popover(GTK_MENU_BUTTON(state->menu_button), false);
 
   g_signal_connect(state->info_bar, "response", G_CALLBACK(info_response), state);
   /* first child of GtkInfoBar is always GtkRevealer */


### PR DESCRIPTION
Fixes https://github.com/artizirk/wdisplays/issues/9.
Although I don't know why Hyprland displays this abnormally, removing the use of popover in  dropdown menu doesn't seem to cause a regression.
Related document:
https://docs.gtk.org/gtk3/method.MenuButton.set_use_popover.html
https://docs.gtk.org/gtk3/method.MenuButton.set_menu_model.html