### PR TITLE
build: Fix errors with latest wayland release

### DIFF
--- a/src/outputs.c
+++ b/src/outputs.c
@@ -28,10 +28,6 @@
 #include "wlr-screencopy-unstable-v1-client-protocol.h"
 #include "wlr-layer-shell-unstable-v1-client-protocol.h"
 
-static void noop() {
-  // This space is intentionally left blank
-}
-
 struct wd_pending_config {
   struct wd_state *state;
   struct wl_list *outputs;
@@ -526,7 +522,6 @@ static void output_manager_handle_done(void *data,
 static const struct zwlr_output_manager_v1_listener output_manager_listener = {
   .head = output_manager_handle_head,
   .done = output_manager_handle_done,
-  .finished = noop,
 };
 static void registry_handle_global(void *data, struct wl_registry *registry,
     uint32_t name, const char *interface, uint32_t version) {
@@ -553,7 +548,6 @@ static void registry_handle_global(void *data, struct wl_registry *registry,
 
 static const struct wl_registry_listener registry_listener = {
   .global = registry_handle_global,
-  .global_remove = noop,
 };
 
 void wd_add_output_management_listener(struct wd_state *state, struct
@@ -603,10 +597,7 @@ static void output_name(void *data, struct zxdg_output_v1 *zxdg_output_v1,
 
 static const struct zxdg_output_v1_listener output_listener = {
   .logical_position = output_logical_position,
-  .logical_size = noop,
-  .done = noop,
   .name = output_name,
-  .description = noop
 };
 
 void wd_add_output(struct wd_state *state, struct wl_output *wl_output,


### PR DESCRIPTION
Fixes build failure:

```
../src/outputs.c:529:15: error: initialization of ‘void (*)(void *, struct zwlr_output_manager_v1 *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  529 |   .finished = noop,
      |               ^~~~
../src/outputs.c:529:15: note: (near initialization for ‘output_manager_listener.finished’)
../src/outputs.c:31:13: note: ‘noop’ declared here
   31 | static void noop() {
      |             ^~~~
../src/outputs.c:556:20: error: initialization of ‘void (*)(void *, struct wl_registry *, uint32_t)’ {aka ‘void (*)(void *, struct wl_registry *, unsigned int)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  556 |   .global_remove = noop,
      |                    ^~~~
../src/outputs.c:556:20: note: (near initialization for ‘registry_listener.global_remove’)
../src/outputs.c:31:13: note: ‘noop’ declared here
   31 | static void noop() {
      |             ^~~~
../src/outputs.c:606:19: error: initialization of ‘void (*)(void *, struct zxdg_output_v1 *, int32_t,  int32_t)’ {aka ‘void (*)(void *, struct zxdg_output_v1 *, int,  int)’} from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  606 |   .logical_size = noop,
      |                   ^~~~
../src/outputs.c:606:19: note: (near initialization for ‘output_listener.logical_size’)
../src/outputs.c:31:13: note: ‘noop’ declared here
   31 | static void noop() {
      |             ^~~~
../src/outputs.c:607:11: error: initialization of ‘void (*)(void *, struct zxdg_output_v1 *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  607 |   .done = noop,
      |           ^~~~
../src/outputs.c:607:11: note: (near initialization for ‘output_listener.done’)
../src/outputs.c:31:13: note: ‘noop’ declared here
   31 | static void noop() {
      |             ^~~~
../src/outputs.c:609:18: error: initialization of ‘void (*)(void *, struct zxdg_output_v1 *, const char *)’ from incompatible pointer type ‘void (*)(void)’ [-Wincompatible-pointer-types]
  609 |   .description = noop
      |                  ^~~~
../src/outputs.c:609:18: note: (near initialization for ‘output_listener.description’)
../src/outputs.c:31:13: note: ‘noop’ declared here
   31 | static void noop() {
      |             ^~~~
[29/31] Compiling C object src/wdisplays.p/main.c.o
../src/main.c: In function ‘main’:
../src/main.c:1086:3: warning: ‘G_APPLICATION_FLAGS_NONE’ is deprecated: Use 'G_APPLICATION_DEFAULT_FLAGS' instead [-Wdeprecated-declarations]
 1086 |   GtkApplication *app = gtk_application_new(WDISPLAYS_APP_ID, G_APPLICATION_FLAGS_NONE);
      |   ^~~~~~~~~~~~~~
In file included from /usr/include/glib-2.0/gio/giotypes.h:30,
                 from /usr/include/glib-2.0/gio/gio.h:28,
                 from /usr/include/gtk-3.0/gdk/gdkapplaunchcontext.h:28,
                 from /usr/include/gtk-3.0/gdk/gdk.h:32,
                 from /usr/include/gtk-3.0/gtk/gtk.h:30,
                 from ../src/main.c:4:
/usr/include/glib-2.0/gio/gioenums.h:1556:3: note: declared here
 1556 |   G_APPLICATION_FLAGS_NONE GIO_DEPRECATED_ENUMERATOR_IN_2_74_FOR(G_APPLICATION_DEFAULT_FLAGS),
      |   ^~~~~~~~~~~~~~~~~~~~~~~~
[30/31] Compiling C object src/wdisplays.p/render.c.o
ninja: build stopped: subcommand failed.
```