### PR TITLE
Allow applying pending changes with Ctrl+Return

### DIFF
--- a/resources/wdisplays.ui
+++ b/resources/wdisplays.ui
@@ -302,6 +302,7 @@
                 <style>
                   <class name="suggested-action"/>
                 </style>
+                <accelerator key="Return" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
               </object>
               <packing>
                 <property name="pack_type">end</property>


### PR DESCRIPTION
Currently, pressing Return in a form field stages the change but does not apply it to the compositor - the user must reach for the Apply button with the mouse. This adds Ctrl+Return as a keyboard shortcut to apply pending changes immediately, without leaving the keyboard.

The shortcut is only active while the "Apply" button is shown, so it is a no-op when there is nothing pending. The implementation follows the same pattern as the existing Ctrl+−/0/+ zoom shortcuts: a single <accelerator> element on the button in wdisplays.ui.